### PR TITLE
DNA Fixes and Enhancements

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -49,7 +49,7 @@
 	var/n     = 1
 
 	// Figure out power. (power of 2)
-	while (n < num)
+	while (n <= num)
 		power += 4
 		n     *= 16
 

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -173,7 +173,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 // Set a DNA UI block's raw value.
 /datum/dna/proc/SetUIValue(var/block,var/value,var/defer=0)
 	if (block<=0) return
-	ASSERT(value>0)
+	ASSERT(value>=0)
 	ASSERT(value<=4095)
 	UI[block]=value
 	dirtyUI=1
@@ -189,7 +189,6 @@ var/global/list/datum/dna/gene/dna_genes[0]
 // Used in hair and facial styles (value being the index and maxvalue being the len of the hairstyle list)
 /datum/dna/proc/SetUIValueRange(var/block,var/value,var/maxvalue,var/defer=0)
 	if (block<=0) return
-	if (value==0) value = 1   // FIXME: hair/beard/eye RGB values if they are 0 are not set, this is a work around we'll encode it in the DNA to be 1 instead.
 	ASSERT(maxvalue<=4095)
 	var/range = (4095 / maxvalue)
 	if(value)
@@ -199,7 +198,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 /datum/dna/proc/GetUIValueRange(var/block,var/maxvalue)
 	if (block<=0) return 0
 	var/value = GetUIValue(block)
-	return round(1 +(value / 4096)*maxvalue)
+	return round(0.5+(value / 4095)*maxvalue)
 
 // Is the UI gene "on" or "off"?
 // For UI, this is simply a check of if the value is > 2050.

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -156,22 +156,30 @@
 
 		//Hair
 		var/hair = dna.GetUIValueRange(DNA_UI_HAIR_STYLE,hair_styles_list.len)
+		if(hair == 0)
+			hair = 1
 		if((0 < hair) && (hair <= hair_styles_list.len))
 			H.h_style = hair_styles_list[hair]
 
 		//Facial Hair
 		var/beard = dna.GetUIValueRange(DNA_UI_BEARD_STYLE,facial_hair_styles_list.len)
+		if(beard == 0)
+			beard = 1
 		if((0 < beard) && (beard <= facial_hair_styles_list.len))
 			H.f_style = facial_hair_styles_list[beard]
 
 		//Ears
 		var/ears = dna.GetUIValueRange(DNA_UI_EAR_STYLE,ear_styles_list.len)
-		if((0 < ears) && (ears <= ear_styles_list.len))
+		if(ears == 0)
+			H.ear_style = null
+		else if((0 < ears) && (ears <= ear_styles_list.len))
 			H.ear_style = ear_styles_list[ear_styles_list[ears]]
 
 		//Tail
 		var/tail = dna.GetUIValueRange(DNA_UI_TAIL_STYLE,tail_styles_list.len)
-		if((0 < tail) && (tail <= tail_styles_list.len))
+		if(tail == 0)
+			H.tail_style = null
+		else if((0 < tail) && (tail <= tail_styles_list.len))
 			H.tail_style = tail_styles_list[tail_styles_list[tail]]
 
 

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -12,7 +12,7 @@
 	var/greaterform = "Human"                  // Used when humanizing a monkey.
 	icon_state = "monkey1"
 	//var/uni_append = "12C4E2"                // Small appearance modifier for different species.
-	var/list/uni_append = list(0x12C,0x4E2)    // Same as above for DNA2.
+	var/list/uni_append = list(0x12C,0x4E2,0x00,0x00,0x00)    // Same as above for DNA2.
 	var/update_muts = 1                        // Monkey gene must be set at start.
 
 /mob/living/carbon/monkey/tajara
@@ -21,7 +21,7 @@
 	speak_emote = list("mews")
 	icon_state = "tajkey1"
 	greaterform = "Tajara"
-	uni_append = list(0x0A0,0xE00) // 0A0E00
+	uni_append = list(0x0A0,0xE00,0x00,0x00,0x00) // 0A0E00
 
 /mob/living/carbon/monkey/skrell
 	name = "neaera"
@@ -29,7 +29,7 @@
 	speak_emote = list("squicks")
 	icon_state = "skrellkey1"
 	greaterform = "Skrell"
-	uni_append = list(0x01C,0xC92) // 01CC92
+	uni_append = list(0x01C,0xC92,0x00,0x00,0x00) // 01CC92
 
 /mob/living/carbon/monkey/unathi
 	name = "stok"
@@ -37,7 +37,7 @@
 	speak_emote = list("hisses")
 	icon_state = "stokkey1"
 	greaterform = "Unathi"
-	uni_append = list(0x044,0xC5D) // 044C5D
+	uni_append = list(0x044,0xC5D,0x00,0x00,0x00) // 044C5D
 
 /mob/living/carbon/monkey/New()
 


### PR DESCRIPTION
- Fixed num2hex bug
  - Yeah.  Fixed #209 (num2hex) Making it so that 1 and multiples of 16 don't return "000"
- Fixed support for zero-value UI blocks in DNA
  - Fixed the refusal of UI blocks to store zero values.  Now that num2hex is fixed, this is now a possibility.
- Prevent Monkeys from starting with custom ears/tails/tau
  - Three new UI blocks were added.  We do not want monkeys to start off as taurs, or with fox tails, so we initialize these UI blocks to zero.
